### PR TITLE
Support for Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,13 @@
 # macOS.
 .DS_Store
 
+# Terraform.
+*.tfstate
+*.tfstate.backup
+*.tfstate.lock.info
+*.tfvars
+.terraform/
+
 # Vagrant.
 .vagrant/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,12 @@ repos:
       - id: destroyed-symlinks
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/gruntwork-io/pre-commit
+    rev: v0.1.12
+    hooks:
+      - id: terraform-fmt
+      - id: terraform-validate
+  - repo: https://github.com/hadolint/hadolint
+    rev: v1.23.0
+    hooks:
+      - id: hadolint-docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,19 @@ FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list && \
-    apt-get update -y && \
-    apt-get install -y curl default-jdk python-is-python3 && \
-    rm -rf /var/lib/apt/lists/*
+RUN sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list \
+    && apt-get update --yes \
+    && apt-get install --yes --no-install-recommends \
+        curl=7.68.0-1ubuntu2.4 \
+        default-jdk=2:1.11-72 \
+        python-is-python3=3.8.2-4 \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN curl -O https://downloads.apache.org/spark/spark-3.0.2/spark-3.0.2-bin-hadoop3.2.tgz && \
-    tar xvf spark-3.0.2-bin-hadoop3.2.tgz && \
-    mv spark-3.0.2-bin-hadoop3.2 /opt/spark && \
-    rm spark-3.0.2-bin-hadoop3.2.tgz && \
-    curl -O https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop3-2.2.0.jar && \
-    mv gcs-connector-hadoop3-2.2.0.jar /opt/spark/jars/
+RUN curl -O https://downloads.apache.org/spark/spark-3.0.2/spark-3.0.2-bin-hadoop3.2.tgz \
+    && tar xvf spark-3.0.2-bin-hadoop3.2.tgz \
+    && mv spark-3.0.2-bin-hadoop3.2 /opt/spark \
+    && rm spark-3.0.2-bin-hadoop3.2.tgz \
+    && curl -O https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop3-2.2.0.jar \
+    && mv gcs-connector-hadoop3-2.2.0.jar /opt/spark/jars/
 
 LABEL org.opencontainers.image.source https://github.com/wager/platform

--- a/terraform/aws/.terraform.lock.hcl
+++ b/terraform/aws/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.31.0"
+  constraints = "~> 3.31.0"
+  hashes = [
+    "h1:QN/kgOC46kY001+vM/nnmJshzAOnWN+kLLpFG9ALcMU=",
+    "zh:07f5b2f4cfaa25e26a4062ac675e3e5aaf65bb21b94b8fd7f30d576398e7410f",
+    "zh:08a2154ad29ae130ea9e46948b7b332ec4b45321b4852b45ba60adcfd049f8d6",
+    "zh:35ed643c2b999021ad56b49f7d9d3a77c98d152477fe54b5c8a68f696bb1a0b7",
+    "zh:3a8dc51b4be1c04130fd76cda4280019020b276336d307e7074ad52f35d4fdda",
+    "zh:3c910c4f25e3ffd6d84f051c32161f03d1843753cd545e769757d7b42d654003",
+    "zh:5d23f316f89937cbda36207271bbe150f633298f96d4644fd02063fc6bf0c28f",
+    "zh:61fedb2915c5188c6550677a10acb955f32834bbe99ba0cafb2a118be282827b",
+    "zh:65076a6899c0781ce95064d47d587ad07f80becd1510e4c475e4554131caec09",
+    "zh:acca833c2d9985e46298323222285b370ea7cf5299b131dbdfc7c3e66fa32401",
+    "zh:c212cf8ba7fdf64e75accf7e745f76d2349b00553ebd928cc6cafbfda99d97b7",
+    "zh:cd3f5e89ac5f5cf3f8fed3aca4cc50261d537b60a3490feaddf9ba2f06e5e7aa",
+  ]
+}

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -1,0 +1,91 @@
+# A platform built on Amazon Web Services.
+terraform {
+  backend "s3" {
+    bucket         = "wager-terraform"
+    dynamodb_table = "terraform-lock"
+    encrypt        = true
+    key            = "platform/terraform.tfstate"
+    region         = "us-east-1"
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.31.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# A virtual private cloud.
+resource "aws_vpc" "vpc" {
+  cidr_block           = "10.1.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+# A publicly visible subnet.
+resource "aws_subnet" "public" {
+  availability_zone       = var.aws_availability_zone
+  cidr_block              = "10.1.0.0/24"
+  map_public_ip_on_launch = true
+  vpc_id                  = aws_vpc.vpc.id
+}
+
+resource "aws_internet_gateway" "internet_gateway" {
+  vpc_id = aws_vpc.vpc.id
+}
+
+resource "aws_route_table" "route_table" {
+  vpc_id = aws_vpc.vpc.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.internet_gateway.id
+  }
+}
+
+resource "aws_route_table_association" "route_table_association" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.route_table.id
+}
+
+# A firewall configuration for Vagrant boxes.
+resource "aws_security_group" "vagrant" {
+  name   = "vagrant"
+  vpc_id = aws_vpc.vpc.id
+
+  ingress {
+    description = "Allow incoming SSH."
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Allow incoming Docsify."
+    from_port   = 3000
+    to_port     = 3000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Allow incoming Jupyter."
+    from_port   = 8888
+    to_port     = 8888
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "Allow all outgoing."
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -1,0 +1,9 @@
+output "public_subnet_id" {
+  value       = aws_subnet.public.id
+  description = "Identifier of the public subnet."
+}
+
+output "vagrant_security_group_id" {
+  value       = aws_security_group.vagrant.id
+  description = "Identifier of the Vagrant security group."
+}

--- a/terraform/aws/setup/.terraform.lock.hcl
+++ b/terraform/aws/setup/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.31.0"
+  constraints = "~> 3.31.0"
+  hashes = [
+    "h1:QN/kgOC46kY001+vM/nnmJshzAOnWN+kLLpFG9ALcMU=",
+    "zh:07f5b2f4cfaa25e26a4062ac675e3e5aaf65bb21b94b8fd7f30d576398e7410f",
+    "zh:08a2154ad29ae130ea9e46948b7b332ec4b45321b4852b45ba60adcfd049f8d6",
+    "zh:35ed643c2b999021ad56b49f7d9d3a77c98d152477fe54b5c8a68f696bb1a0b7",
+    "zh:3a8dc51b4be1c04130fd76cda4280019020b276336d307e7074ad52f35d4fdda",
+    "zh:3c910c4f25e3ffd6d84f051c32161f03d1843753cd545e769757d7b42d654003",
+    "zh:5d23f316f89937cbda36207271bbe150f633298f96d4644fd02063fc6bf0c28f",
+    "zh:61fedb2915c5188c6550677a10acb955f32834bbe99ba0cafb2a118be282827b",
+    "zh:65076a6899c0781ce95064d47d587ad07f80becd1510e4c475e4554131caec09",
+    "zh:acca833c2d9985e46298323222285b370ea7cf5299b131dbdfc7c3e66fa32401",
+    "zh:c212cf8ba7fdf64e75accf7e745f76d2349b00553ebd928cc6cafbfda99d97b7",
+    "zh:cd3f5e89ac5f5cf3f8fed3aca4cc50261d537b60a3490feaddf9ba2f06e5e7aa",
+  ]
+}

--- a/terraform/aws/setup/main.tf
+++ b/terraform/aws/setup/main.tf
@@ -1,0 +1,50 @@
+# An S3 Terraform backend.
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.31.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+# A S3 bucket that stores the Terraform state.
+resource "aws_s3_bucket" "terraform_state" {
+  bucket = "wager-terraform"
+  acl    = "private"
+  tags   = { Name = "Terraform State" }
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+# A DynamoDB table that is used to synchronize operations on the Terraform state.
+resource "aws_dynamodb_table" "terraform_lock" {
+  name           = "terraform-lock"
+  hash_key       = "LockID"
+  read_capacity  = 20
+  write_capacity = 20
+  tags           = { Name = "Terraform Lock" }
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}

--- a/terraform/aws/setup/variables.tf
+++ b/terraform/aws/setup/variables.tf
@@ -1,0 +1,1 @@
+../variables.tf

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -1,0 +1,11 @@
+variable "aws_region" {
+  type        = string
+  description = "AWS region."
+  default     = "us-east-1"
+}
+
+variable "aws_availability_zone" {
+  type        = string
+  description = "AWS availability zone."
+  default     = "us-east-1a"
+}

--- a/terraform/google/.terraform.lock.hcl
+++ b/terraform/google/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "3.58.0"
+  constraints = "~> 3.58.0"
+  hashes = [
+    "h1:7Ve+5b5xes0XLEoOg1v69Fb4OMoAJAwLkzsdLy8+tPM=",
+    "zh:11429956acf63eff104d430bbf8d61977f67eadfe79ed3fae5823f76223f7a38",
+    "zh:25e448f7fcd5a96ae6bb84b6ae0ba9275595c671f1c3ae5332d48193cadbb23b",
+    "zh:4dc858b85c0981f4e55b3003882f496076ad95b7684fb0edc6c1c2dac063f193",
+    "zh:5348a8d20b3d56447acb3f471ad9e3887f66bf73f5b803cf10cd77817a8b3b6c",
+    "zh:733659cb1106c93c0e5df99ad4d6e13fbeefa50a2efcea2d160ec88657ee6a01",
+    "zh:7cd0c23396c473cd43e61a8aa72c87b170cfdf4816335d0e1e61c1d1d0ebbaf4",
+    "zh:87543121139f427a7bdea104f226e6cc3e267db66f08dc9294e8f2a953856d35",
+    "zh:a858ea9a879037e643d1ab7e387e6312369df7740d88f6068b406f4c15dda003",
+    "zh:b666f26c051cf82a063ab902ba0031db7ca9b7138cdcf00645e594b347630df1",
+    "zh:dd6d294a2238b83893eb2df00f8d0f0a3fb9841e6cc5f9a2b135a3d5c1e44ee6",
+  ]
+}

--- a/terraform/google/main.tf
+++ b/terraform/google/main.tf
@@ -1,0 +1,64 @@
+# A platform built on Google Cloud.
+terraform {
+  backend "gcs" {
+    bucket = "wager-terraform"
+    prefix = "platform"
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.58.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.google_project_id
+  region  = var.google_region
+  zone    = var.google_zone
+}
+
+# A virtual private cloud.
+resource "google_compute_network" "vpc" {
+  name = "vpc"
+}
+
+# A firewall rule that exposes tcp:22 on Vagrant boxes for SSH.
+resource "google_compute_firewall" "allow_ssh" {
+  name          = "allow-ssh"
+  network       = google_compute_network.vpc.name
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["vagrant"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+}
+
+# A firewall rule that exposes tcp:3000 on Vagrant boxes for Docsify.
+resource "google_compute_firewall" "allow_docsify" {
+  name          = "allow-docsify"
+  network       = google_compute_network.vpc.name
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["vagrant"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["3000"]
+  }
+}
+
+# A firewall rule that exposes tcp:8888 on Vagrant boxes for Jupyter.
+resource "google_compute_firewall" "allow_jupyter" {
+  name          = "allow-jupyter"
+  network       = google_compute_network.vpc.name
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["vagrant"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["8888"]
+  }
+}

--- a/terraform/google/setup/.terraform.lock.hcl
+++ b/terraform/google/setup/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "3.58.0"
+  constraints = "~> 3.58.0"
+  hashes = [
+    "h1:7Ve+5b5xes0XLEoOg1v69Fb4OMoAJAwLkzsdLy8+tPM=",
+    "zh:11429956acf63eff104d430bbf8d61977f67eadfe79ed3fae5823f76223f7a38",
+    "zh:25e448f7fcd5a96ae6bb84b6ae0ba9275595c671f1c3ae5332d48193cadbb23b",
+    "zh:4dc858b85c0981f4e55b3003882f496076ad95b7684fb0edc6c1c2dac063f193",
+    "zh:5348a8d20b3d56447acb3f471ad9e3887f66bf73f5b803cf10cd77817a8b3b6c",
+    "zh:733659cb1106c93c0e5df99ad4d6e13fbeefa50a2efcea2d160ec88657ee6a01",
+    "zh:7cd0c23396c473cd43e61a8aa72c87b170cfdf4816335d0e1e61c1d1d0ebbaf4",
+    "zh:87543121139f427a7bdea104f226e6cc3e267db66f08dc9294e8f2a953856d35",
+    "zh:a858ea9a879037e643d1ab7e387e6312369df7740d88f6068b406f4c15dda003",
+    "zh:b666f26c051cf82a063ab902ba0031db7ca9b7138cdcf00645e594b347630df1",
+    "zh:dd6d294a2238b83893eb2df00f8d0f0a3fb9841e6cc5f9a2b135a3d5c1e44ee6",
+  ]
+}

--- a/terraform/google/setup/main.tf
+++ b/terraform/google/setup/main.tf
@@ -1,0 +1,24 @@
+# A GCS Terraform backend.
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.58.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.google_project_id
+  region  = var.google_region
+  zone    = var.google_zone
+}
+
+# A GCS bucket that stores the Terraform state.
+resource "google_storage_bucket" "terraform_state" {
+  name = "wager-terraform"
+
+  versioning {
+    enabled = true
+  }
+}

--- a/terraform/google/setup/variables.tf
+++ b/terraform/google/setup/variables.tf
@@ -1,0 +1,1 @@
+../variables.tf

--- a/terraform/google/variables.tf
+++ b/terraform/google/variables.tf
@@ -1,0 +1,17 @@
+variable "google_project_id" {
+  type        = string
+  description = "Google Cloud project identifier."
+  default     = "wager-233003"
+}
+
+variable "google_region" {
+  type        = string
+  description = "Google Cloud region."
+  default     = "us-east1"
+}
+
+variable "google_zone" {
+  type        = string
+  description = "Google Cloud zone."
+  default     = "us-east1-a"
+}


### PR DESCRIPTION
- (Untested) support for AWS EC2 VMs.
- (Untested) support for terraforming infrastructure on AWS and GCP.
- Pre-commit hooks for Terraform and Docker.
- Submitted a PR for a Vagrant pre-commit hook to upstream. https://github.com/hashicorp/vagrant/pull/12220